### PR TITLE
to send stop command in urg3d_open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*.exe
+*.csv
+*.o
+*.a
+*.dll
+*.so
+Debug/
+*.user
+Release/
+ipch/
+*.sdf
+*.suo
+*.opensdf
+urg3d-config

--- a/src/urg3d_sensor.c
+++ b/src/urg3d_sensor.c
@@ -37,6 +37,11 @@ int urg3d_open(urg3d_t* const urg
         return urg->last_errno;
     }
 
+    // stop the acquisition data.
+    if((ret = urg3d_high_stop_data(urg, URG3D_DISTANCE_INTENSITY)) < 0) {
+        return ret;
+    }
+
     urg->is_active = URG_TRUE;
     return 0;
 }


### PR DESCRIPTION
If sensor is sending some data state, urg3d_high_blocking_init sometimes fail.
So, send stop command in urg3d_open to avoid the problem.